### PR TITLE
Release version 0.6.5: Fix --disable-prefilter bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ specimux-convert Index.txt --output-specimen=IndexPP.txt --output-primers=primer
 - `--pool-name`: Name to use for the primer pool (default: pool1)
 
 ## Version History
+- 0.6.5 (October 2025): Fix bug in --disable-prefilter flag where code attempted to call .match() on None prefilter object, causing AttributeError. Updated type hints to Optional[BarcodePrefilter] and added None check before prefilter usage
 - 0.6.4 (October 2025): Change default output file prefix from "sample_" to empty string for cleaner filenames. All tools (specimux, specimux-watch, specimine) now produce files like "specimen_001.fastq" instead of "sample_specimen_001.fastq". Backward compatible with legacy "sample_" prefixed files. Users can still specify custom prefix with -P flag
 - 0.6.3 (October 2025): Add specimux-watch for live MinKNOW sequencing workflows with automatic file monitoring and processing. Fix duplicate output bug when primers belong to multiple pools. Pool assignment now uses the attempted primer pair context rather than matched primers. Fix empty directory pruning to ignore primer metadata files when determining if a directory should be removed. Update validation script to handle sequences appearing in multiple locations
 - 0.6.2 (August 2025): Fix primer orientation detection bug introduced in commit f0209a3 (January 29, 2025). The determine_orientation function now correctly searches for reverse primers at the beginning of the reverse complement sequence, properly detecting sequence orientation for pre-filtering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specimux"
-version = "0.6.4"
+version = "0.6.5"
 description = "Dual barcode and primer demultiplexing system for MinION sequenced reads"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/specimux/__init__.py
+++ b/src/specimux/__init__.py
@@ -1,7 +1,7 @@
 """Specimux: Demultiplexing tools for MinION sequenced reads."""
 
 # IMPORTANT: When updating version, also update cli.py version() function
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 # Import key classes and functions from the refactored modules
 from .databases import PrimerDatabase, Specimens

--- a/src/specimux/cli.py
+++ b/src/specimux/cli.py
@@ -15,7 +15,7 @@ def version():
     # 0.4 February 1, 2025 - bloom filter acceleration
     # 0.5 March 19, 2025 - added Primer Pools, Hierarchical Output with pool-level full match collections, and detailed run log
     # 0.6 August 2025 - multiple match processing, comprehensive trace event system, trace-based statistics framework
-    return "specimux version 0.6.4"
+    return "specimux version 0.6.5"
 
 
 def parse_args(argv):

--- a/src/specimux/demultiplex.py
+++ b/src/specimux/demultiplex.py
@@ -79,7 +79,7 @@ def process_sequences(seq_records: List[SeqRecord],
                       parameters: MatchParameters,
                       specimens: Specimens,
                       args: argparse.Namespace,
-                      prefilter: BarcodePrefilter,
+                      prefilter: Optional[BarcodePrefilter],
                       trace_logger: Optional[TraceLogger] = None,
                       record_offset: int = 0) -> Tuple[List[WriteOperation], int, int]:
     """Process sequences and track pipeline events.
@@ -335,7 +335,7 @@ def get_pool_from_primers(p1: Optional[PrimerInfo], p2: Optional[PrimerInfo]) ->
     return None
 
 
-def find_candidate_matches(prefilter: BarcodePrefilter, parameters: MatchParameters, seq: SeqRecord,
+def find_candidate_matches(prefilter: Optional[BarcodePrefilter], parameters: MatchParameters, seq: SeqRecord,
                            rseq: SeqRecord, specimens: Specimens,
                            trace_logger: Optional[TraceLogger] = None,
                            sequence_id: Optional[str] = None) -> List[CandidateMatch]:
@@ -415,7 +415,7 @@ def find_candidate_matches(prefilter: BarcodePrefilter, parameters: MatchParamet
     # for cases where multiple primer pairs cover nearly identical sequence regions.
     return matches
 
-def match_one_end(prefilter: BarcodePrefilter, match: CandidateMatch, parameters: MatchParameters, sequence: str,
+def match_one_end(prefilter: Optional[BarcodePrefilter], match: CandidateMatch, parameters: MatchParameters, sequence: str,
                   reversed_sequence: bool, primer_info: PrimerInfo,
                   which_primer: Primer, which_barcode: Barcode,
                   trace_logger: Optional[TraceLogger] = None,
@@ -463,7 +463,7 @@ def match_one_end(prefilter: BarcodePrefilter, match: CandidateMatch, parameters
                     trace_logger.log_barcode_search(sequence_id, b, which_barcode.to_string(), primer_info.name,
                                                    barcode_search_start, barcode_search_end, False, -1, -1)
                 
-                if not prefilter.match(b_rc, target_seq):
+                if prefilter and not prefilter.match(b_rc, target_seq):
                     continue
 
                 barcode_match = align_seq(b_rc, sequence, parameters.max_dist_index,


### PR DESCRIPTION
Fix bug where --disable-prefilter flag caused AttributeError when code attempted to call .match() on None prefilter object. Updated type hints to Optional[BarcodePrefilter] and added None check before prefilter usage in demultiplex.py:466.

Changes:
- demultiplex.py: Update type hints to Optional[BarcodePrefilter]
- demultiplex.py: Add None check before prefilter.match() call
- pyproject.toml: Bump version to 0.6.5
- __init__.py: Bump version to 0.6.5
- cli.py: Bump version to 0.6.5
- README.md: Add 0.6.5 to version history

🤖 Generated with [Claude Code](https://claude.com/claude-code)