### PR TITLE
Release version 0.7.2: Add profile system, progress reporting, deprecate specimux-watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Specimux automatically installs these dependencies:
 - tqdm>=4.65.0 (progress bars)
 - plotly>=5.0.0 (visualization support)
 - watchdog>=3.0.0 (file system monitoring for specimux-watch)
+- pyyaml>=5.0 (profile system)
 
 Specimux has been tested on MacOS and Linux machines.
 
@@ -84,7 +85,7 @@ Specimux has been tested on MacOS and Linux machines.
 After installation, specimux provides several command-line tools:
 
 - **`specimux`** - Main demultiplexer for dual barcode and primer matching
-- **`specimux-watch`** - Automatic file watcher for live MinKNOW sequencing workflows
+- **`specimux-watch`** - *(Deprecated)* File watcher for live sequencing — use `specimux-suite live` instead
 - **`specimine`** - Mine additional sequences from partial barcode matches
 - **`specimux-convert`** - Convert legacy specimen files to current format
 - **`specimux-stats`** - Analyze trace files to generate statistics
@@ -134,6 +135,67 @@ For a full list of options:
 ```bash
 specimux -h
 ```
+
+## Profiles
+
+Profiles allow you to save and reuse parameter presets for different workflows. A profile is a YAML file that sets default values for specimux options — any option explicitly provided on the command line overrides the profile value.
+
+### Using Profiles
+
+```bash
+# List available profiles
+specimux --list-profiles
+
+# Run with a profile
+specimux primers.fasta specimens.txt sequences.fastq -p default -F -d
+
+# CLI arguments override profile values
+specimux primers.fasta specimens.txt sequences.fastq -p default --search-len 120
+```
+
+### Profile Resolution
+
+Profiles are loaded in this order (first match wins):
+1. User profiles in `~/.config/specimux/profiles/`
+2. Bundled profiles shipped with the package
+
+### Creating Custom Profiles
+
+Copy the example profile that is created in `~/.config/specimux/profiles/` on first use:
+
+```bash
+cp ~/.config/specimux/profiles/example.yaml ~/.config/specimux/profiles/my-workflow.yaml
+```
+
+Edit the file to set your preferred defaults. Only include parameters you want to change:
+
+```yaml
+specimux-version: "0.7.*"
+description: "My custom workflow"
+
+specimux:
+  search-len: 120
+  trim: primers
+  threads: 8
+```
+
+### Available Profile Parameters
+
+Profiles support the following specimux parameters: `trim`, `dereplicate`, `search-len`, `index-edit-distance`, `primer-edit-distance`, `min-length`, `max-length`, `threads`, `disable-prefilter`, `disable-preorient`, `sample-topq`, `diagnostics`.
+
+### Version Compatibility
+
+Each profile declares a `specimux-version` pattern (e.g., `"0.7.*"`). Specimux validates this on load and raises an error if the profile is incompatible with the installed version, preventing silent parameter mismatches after upgrades.
+
+## Progress Reporting
+
+For integration with orchestration tools like specimux-suite, specimux can write JSONL progress updates to a file:
+
+```bash
+specimux primers.fasta specimens.txt sequences.fastq -F --progress-file progress.jsonl
+```
+
+Each line is a JSON object with `type` (`"progress"` or `"complete"`), `processed`, `matched`, and `rate` fields. Progress lines are throttled to at most one per second.
 
 ## Primer Pool Organization
 
@@ -388,7 +450,9 @@ output/
         └── specimen_001.fastq (500 sequences)
 ```
 
-### Live Sequencing with specimux-watch
+### Live Sequencing with specimux-watch (Deprecated)
+
+> **Note:** `specimux-watch` is deprecated. Use `specimux-suite live` for live sequencing monitoring with consensus and identification.
 
 For live MinKNOW sequencing workflows, `specimux-watch` automatically monitors a directory and processes new FASTQ files as they are written:
 
@@ -624,6 +688,7 @@ specimux-convert Index.txt --output-specimen=IndexPP.txt --output-primers=primer
 - `--pool-name`: Name to use for the primer pool (default: pool1)
 
 ## Version History
+- 0.7.2 (March 2026): Add profile system for reusable parameter presets (`-p/--profile`, `--list-profiles`). Profiles are YAML files stored in `~/.config/specimux/profiles/` or bundled with the package, with version compatibility checking and key validation. Add JSONL progress reporting (`--progress-file`) for integration with orchestration tools. Deprecate `specimux-watch` in favor of `specimux-suite live`
 - 0.7.1 (March 2026): Deduplicate "No Specimens for combo" warning that flooded output with thousands of per-sequence messages. Unregistered barcode combinations now produce a single end-of-run summary warning instead. Per-sequence detail remains available at DEBUG level (-d3). PrimerInfo objects now display their name in log messages instead of memory addresses. Fixes #9
 - 0.7.0 (January 2026): Add dereplication to prevent artificial read amplification. When complex primer pools cause the same read to match multiple primer permutations, specimux now selects the best match per specimen/barcode group by default. New `--dereplicate` option replaces `--resolve-multiple-matches` with values `best` (default) and `none`. The `downgrade-full` strategy has been removed. Also fixes a bug where ~180 reads per run were silently dropped when trimming would produce empty sequences (now routed to unknown output).
 - 0.6.9 (December 2025): Fix specimine path derivation for current output structure. The tool now correctly finds partial match files after the specimux output reorganization. Also fixes --partial-reverse flag (changed to --no-partial-reverse) which was broken due to argparse store_true with default=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "specimux"
-version = "0.7.1"
+version = "0.7.2"
 description = "Dual barcode and primer demultiplexing system for MinION sequenced reads"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -32,6 +32,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "plotly>=5.0.0",  # Included by default for visualization
     "watchdog>=3.0.0",  # File system monitoring for specimux-watch
+    "pyyaml>=5.0",  # Profile system
 ]
 
 [project.optional-dependencies]
@@ -66,4 +67,4 @@ where = ["src"]
 include = ["specimux*"]
 
 [tool.setuptools.package-data]
-"*" = ["*.txt", "*.fasta", "*.fastq"]
+"*" = ["*.txt", "*.fasta", "*.fastq", "*.yaml"]

--- a/src/specimux/__init__.py
+++ b/src/specimux/__init__.py
@@ -1,6 +1,6 @@
 """Specimux: Demultiplexing tools for MinION sequenced reads."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 # Import key classes and functions from the refactored modules
 from .databases import PrimerDatabase, Specimens

--- a/src/specimux/cli.py
+++ b/src/specimux/cli.py
@@ -3,7 +3,9 @@ import sys
 import argparse
 import logging
 import os
+from pathlib import Path
 from . import core, __version__
+from .progress import ProgressReporter
 from .core import TrimMode, MultipleMatchStrategy
 
 
@@ -41,9 +43,44 @@ def parse_args(argv):
     parser.add_argument("-t", "--threads", type=int, default=-1, help="Number of worker threads to use")
     parser.add_argument("--sample-topq", type=int, default=0, metavar="N",
                         help="Create subsample directories with top N sequences by average quality score (default: disabled)")
+    parser.add_argument("--progress-file", type=str, default=None,
+                        help="Write JSONL progress lines to this file (for orchestration tools)")
     parser.add_argument("-v", "--version", action="version", version=version())
 
-    args = parser.parse_args(argv[1:])
+    parser.add_argument('-p', '--profile', type=str, default=None,
+                        help='Load a profile preset')
+    parser.add_argument('--list-profiles', action='store_true',
+                        help='List available profiles and exit')
+
+    # argv[0] is the program name, argv[1:] are the actual arguments
+    cli_args = argv[1:]
+
+    # Early exit for --list-profiles (before requiring positional args)
+    if '--list-profiles' in cli_args:
+        from .profiles import print_profiles_list
+        print_profiles_list('specimux')
+        sys.exit(0)
+
+    # Track which long-form arguments were explicitly provided on command line.
+    # We need this to distinguish "user set --search-len 120" from
+    # "search_len has its default value of 80".
+    # Short options (-t, -F, etc.) are not tracked — profiles only use long names.
+    explicit_args = set()
+    for arg in cli_args:
+        if arg.startswith('--') and '=' in arg:
+            explicit_args.add(arg.split('=')[0][2:].replace('-', '_'))
+        elif arg.startswith('--'):
+            explicit_args.add(arg[2:].replace('-', '_'))
+
+    # Load and apply profile if specified
+    args, remaining = parser.parse_known_args(cli_args)
+    if args.profile:
+        from .profiles import Profile, apply_profile_to_args
+        profile = Profile.load(args.profile)
+        apply_profile_to_args(args, profile, 'specimux', explicit_args)
+        # Re-parse to let profile defaults fill in
+        parser.set_defaults(**{k: v for k, v in vars(args).items()})
+        args = parser.parse_args(cli_args)
 
     if args.num_seqs:
         process_num_seqs(args, parser)
@@ -102,12 +139,16 @@ def main():
     logging.info(f"Starting {version()}")
     logging.info(f"Command line: {' '.join(sys.argv)}")
 
-    if args.output_to_files:
-        core.specimux_mp(args)  # Use multiprocess for file output
-    else:
-        if args.threads > 1:
-            logging.warning(f"Multithreading only supported for file output. Ignoring --threads {args.threads}")
-        core.specimux(args)     # Use single process for console output
+    reporter = ProgressReporter(Path(args.progress_file) if args.progress_file else None)
+    try:
+        if args.output_to_files:
+            core.specimux_mp(args, progress_reporter=reporter)  # Use multiprocess for file output
+        else:
+            if args.threads > 1:
+                logging.warning(f"Multithreading only supported for file output. Ignoring --threads {args.threads}")
+            core.specimux(args, progress_reporter=reporter)     # Use single process for console output
+    finally:
+        reporter.close()
 
 
 def specimine_main():

--- a/src/specimux/orchestration.py
+++ b/src/specimux/orchestration.py
@@ -150,7 +150,7 @@ def estimate_sequence_count(filename: str, args: argparse.Namespace) -> int:
     return estimated_sequences
 
 
-def specimux_mp(args):
+def specimux_mp(args, progress_reporter=None):
     primer_registry = read_primers_file(args.primer_file)
     specimens = read_specimen_file(args.specimen_file, primer_registry)
     specimens.validate()
@@ -208,14 +208,20 @@ def specimux_mp(args):
                     total_matched += batch_matched
                     total_unregistered += batch_unregistered
                     pbar.update(batch_total)
-                    
+
                     # Update progress with match rate
                     if total_processed > 0:
                         match_rate = total_matched / total_processed
                         pbar.set_description(f"Processing sequences [Match rate: {match_rate:.1%}]")
 
+                    if progress_reporter:
+                        progress_reporter.update(total_processed, total_matched, total_seqs)
+
             pbar.close()
-            
+
+            if progress_reporter:
+                progress_reporter.complete(total_processed, total_matched)
+
             # Log final statistics
             if total_processed > 0:
                 final_match_rate = total_matched / total_processed
@@ -461,7 +467,7 @@ def iter_batches(seq_records, batch_size: int, max_seqs: int, all_seqs: bool):
         yield batch
         num_seqs += len(batch)
 
-def specimux(args):
+def specimux(args, progress_reporter=None):
     primer_registry = read_primers_file(args.primer_file)
     specimens = read_specimen_file(args.specimen_file, primer_registry)
     specimens.validate()
@@ -532,14 +538,20 @@ def specimux(args):
             total_matched += batch_matched
             total_unregistered += batch_unregistered
             pbar.update(batch_total)
-            
+
             # Update progress with match rate
             if total_processed > 0:
                 match_rate = total_matched / total_processed
                 pbar.set_description(f"Processing sequences [Match rate: {match_rate:.1%}]")
 
+            if progress_reporter:
+                progress_reporter.update(total_processed, total_matched, total_seqs)
+
         pbar.close()
-        
+
+        if progress_reporter:
+            progress_reporter.complete(total_processed, total_matched)
+
         # Log final statistics
         if total_processed > 0:
             final_match_rate = total_matched / total_processed

--- a/src/specimux/profiles/__init__.py
+++ b/src/specimux/profiles/__init__.py
@@ -1,0 +1,455 @@
+"""Profile system for specimux parameter presets.
+
+Profiles allow users to save and reuse parameter configurations for different
+workflows (e.g., different primer sets, length filtering, threading).
+
+Profile resolution order:
+1. User profiles in ~/.config/specimux/profiles/
+2. Bundled profiles in package
+
+Override order: defaults -> profile -> explicit CLI arguments
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Set
+import logging
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore
+
+try:
+    from specimux import __version__
+except ImportError:
+    __version__ = "dev"
+
+# Use importlib.resources for Python 3.9+, fall back to pkg_resources
+HAS_IMPORTLIB_RESOURCES = False
+HAS_PKG_RESOURCES = False
+
+try:
+    from importlib.resources import files as importlib_files
+    from importlib.resources import as_file
+    HAS_IMPORTLIB_RESOURCES = True
+except ImportError:
+    try:
+        import pkg_resources
+        HAS_PKG_RESOURCES = True
+    except ImportError:
+        pass
+
+logger = logging.getLogger(__name__)
+
+# XDG-compliant config path
+XDG_CONFIG_HOME = Path.home() / ".config"
+PROFILES_DIR = XDG_CONFIG_HOME / "specimux" / "profiles"
+
+# Valid keys for the specimux tool section (drawn from CLI options)
+VALID_SPECIMUX_KEYS = {
+    "trim",
+    "dereplicate",
+    "search-len",
+    "index-edit-distance",
+    "primer-edit-distance",
+    "min-length",
+    "max-length",
+    "threads",
+    "disable-prefilter",
+    "disable-preorient",
+    "sample-topq",
+    "diagnostics",
+}
+
+
+class ProfileError(Exception):
+    """Error loading or applying a profile."""
+    pass
+
+
+class ProfileVersionError(ProfileError):
+    """Profile version is incompatible with current specimux version."""
+    pass
+
+
+class ProfileValidationError(ProfileError):
+    """Profile contains invalid keys."""
+    pass
+
+
+@dataclass
+class Profile:
+    """A parameter profile for specimux."""
+    name: str
+    version: str  # e.g., "0.7.*"
+    description: str
+    specimux: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, name: str, check_version: bool = True) -> 'Profile':
+        """Load profile by name from user dir or bundled.
+
+        Args:
+            name: Profile name (without .yaml extension)
+            check_version: If True, validate version compatibility
+
+        Returns:
+            Loaded Profile instance
+
+        Raises:
+            ProfileError: If profile not found
+            ProfileVersionError: If version incompatible
+            ProfileValidationError: If profile contains invalid keys
+        """
+        if yaml is None:
+            raise ProfileError(
+                "PyYAML is required for profile support. "
+                "Install with: pip install pyyaml"
+            )
+
+        # Initialize user profiles directory with example on first use
+        ensure_user_profiles_dir()
+
+        # Try user profile first
+        user_path = PROFILES_DIR / f"{name}.yaml"
+        if user_path.exists():
+            return cls._load_from_path(user_path, name, check_version)
+
+        # Fall back to bundled profile
+        bundled_path = get_bundled_profile_path(name)
+        if bundled_path is not None:
+            return cls._load_from_path(bundled_path, name, check_version)
+
+        # Profile not found - provide helpful error
+        available = list_profiles()
+        if available:
+            raise ProfileError(
+                f"Profile '{name}' not found. Available profiles: {', '.join(available)}"
+            )
+        else:
+            raise ProfileError(
+                f"Profile '{name}' not found and no profiles are available. "
+                f"Check that profiles are installed in {PROFILES_DIR}"
+            )
+
+    @classmethod
+    def _load_from_path(cls, path: Path, name: str, check_version: bool) -> 'Profile':
+        """Load profile from a specific path."""
+        try:
+            with open(path, 'r') as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise ProfileError(f"Invalid YAML in profile '{name}': {e}")
+        except IOError as e:
+            raise ProfileError(f"Cannot read profile '{name}': {e}")
+
+        if not isinstance(data, dict):
+            raise ProfileError(f"Profile '{name}' must be a YAML mapping")
+
+        # Extract fields
+        version = data.get('specimux-version', '*')
+        description = data.get('description', '')
+        specimux = data.get('specimux', {}) or {}
+
+        # Validate version compatibility
+        if check_version and not check_version_compatible(version, __version__):
+            raise ProfileVersionError(
+                f"Profile '{name}' requires specimux version {version}, "
+                f"but you have {__version__}.\n\n"
+                f"This profile may use parameters that have changed or been removed.\n"
+                f"Please update the profile for your version, or copy the bundled\n"
+                f"'{name}' profile which is compatible with your version:\n\n"
+                f"  cp {PROFILES_DIR}/{name}.yaml {PROFILES_DIR}/{name}.yaml.bak\n"
+                f"  specimux --list-profiles  # Will show available profiles"
+            )
+
+        # Validate keys (strict validation)
+        _validate_profile_keys(name, specimux)
+
+        return cls(
+            name=name,
+            version=version,
+            description=description,
+            specimux=specimux,
+        )
+
+
+def check_version_compatible(profile_version: str, current_version: str) -> bool:
+    """Check if profile version pattern matches current version.
+
+    Supports wildcards:
+    - "0.7.*" matches "0.7.0", "0.7.1", etc.
+    - "0.7.0" matches only "0.7.0"
+    - "0.*" matches any 0.x release
+    - "*" matches any version
+
+    Args:
+        profile_version: Version pattern from profile (e.g., "0.7.*")
+        current_version: Current specimux version (e.g., "0.7.2")
+
+    Returns:
+        True if versions are compatible
+    """
+    if profile_version == '*':
+        return True
+
+    # Convert wildcard pattern to regex
+    # Escape dots and convert * to .*
+    pattern = profile_version.replace('.', r'\.').replace('*', r'.*')
+    pattern = f'^{pattern}$'
+
+    try:
+        return bool(re.match(pattern, current_version))
+    except re.error:
+        # Invalid regex, treat as literal match
+        return profile_version == current_version
+
+
+def _validate_profile_keys(
+    name: str,
+    specimux: Dict[str, Any],
+) -> None:
+    """Validate that profile only contains known keys.
+
+    Raises ProfileValidationError for unknown keys.
+    """
+    unknown = set(specimux.keys()) - VALID_SPECIMUX_KEYS
+    if unknown:
+        raise ProfileValidationError(
+            f"Profile '{name}' contains unknown keys:\n"
+            f"  specimux: {', '.join(sorted(unknown))}\n\n"
+            f"This may indicate a typo or an option that has been removed.\n"
+            f"Please check the profile and fix or remove the invalid keys."
+        )
+
+
+def get_bundled_profile_path(name: str) -> Optional[Path]:
+    """Get path to bundled profile using importlib.resources.
+
+    Args:
+        name: Profile name (without .yaml extension)
+
+    Returns:
+        Path to bundled profile file, or None if not found
+    """
+    if HAS_IMPORTLIB_RESOURCES:
+        try:
+            # Python 3.9+ style
+            profiles_pkg = importlib_files('specimux.profiles')
+            profile_file = profiles_pkg.joinpath(f'{name}.yaml')
+            # Check if file exists using as_file context manager
+            with as_file(profile_file) as path:
+                if path.exists():
+                    return path
+        except (TypeError, FileNotFoundError, ModuleNotFoundError):
+            pass
+
+    if HAS_PKG_RESOURCES:
+        try:
+            # Fall back to pkg_resources for older Python
+            resource_path = pkg_resources.resource_filename(
+                'specimux.profiles', f'{name}.yaml'
+            )
+            path = Path(resource_path)
+            if path.exists():
+                return path
+        except (FileNotFoundError, ModuleNotFoundError):
+            pass
+
+    # Last resort: check relative to this file (profiles/__init__.py)
+    bundled_dir = Path(__file__).parent
+    bundled_path = bundled_dir / f'{name}.yaml'
+    if bundled_path.exists():
+        return bundled_path
+
+    return None
+
+
+def list_bundled_profiles() -> List[str]:
+    """List names of bundled profiles."""
+    profiles = []
+
+    # Try importlib.resources first
+    if HAS_IMPORTLIB_RESOURCES:
+        try:
+            profiles_pkg = importlib_files('specimux.profiles')
+            for item in profiles_pkg.iterdir():
+                if str(item).endswith('.yaml'):
+                    name = Path(str(item)).stem
+                    profiles.append(name)
+            if profiles:
+                return sorted(profiles)
+        except (TypeError, FileNotFoundError, ModuleNotFoundError):
+            pass
+
+    # Fall back to checking directory relative to this file
+    bundled_dir = Path(__file__).parent
+    if bundled_dir.exists():
+        for yaml_file in bundled_dir.glob('*.yaml'):
+            profiles.append(yaml_file.stem)
+
+    return sorted(profiles)
+
+
+def list_profiles() -> List[str]:
+    """List available profiles (user + bundled).
+
+    Returns list of profile names (without .yaml extension).
+    User profiles take precedence over bundled profiles with same name.
+    """
+    profiles: Set[str] = set()
+
+    # User profiles
+    if PROFILES_DIR.exists():
+        for yaml_file in PROFILES_DIR.glob('*.yaml'):
+            profiles.add(yaml_file.stem)
+
+    # Bundled profiles
+    profiles.update(list_bundled_profiles())
+
+    return sorted(profiles)
+
+
+def ensure_user_profiles_dir() -> Path:
+    """Ensure user profiles directory exists with example profile.
+
+    On first use, creates the directory and copies an example profile
+    to help users create their own profiles.
+
+    This function is safe to call from parallel processes - it uses
+    atomic file operations to avoid race conditions.
+
+    Returns:
+        Path to user profiles directory
+    """
+    import tempfile
+
+    PROFILES_DIR.mkdir(parents=True, exist_ok=True)
+
+    example_path = PROFILES_DIR / "example.yaml"
+
+    # Skip if example already exists (common case, avoid extra work)
+    if example_path.exists():
+        return PROFILES_DIR
+
+    # Skip if user already has other profiles (they don't need the example)
+    if any(PROFILES_DIR.glob('*.yaml')):
+        return PROFILES_DIR
+
+    # Copy example profile atomically (safe for parallel invocations)
+    bundled_example = get_bundled_profile_path('example')
+    if bundled_example is not None:
+        try:
+            # Write to temp file in same directory, then atomic rename
+            fd, temp_path = tempfile.mkstemp(
+                dir=PROFILES_DIR,
+                prefix='.example.',
+                suffix='.yaml.tmp'
+            )
+            try:
+                with open(bundled_example, 'rb') as src:
+                    os.write(fd, src.read())
+            finally:
+                os.close(fd)
+
+            # Atomic rename - if file exists, this either succeeds or fails cleanly
+            try:
+                os.rename(temp_path, example_path)
+                logger.info(f"Created example profile at {example_path}")
+            except OSError:
+                # Another process won the race - that's fine
+                if os.path.exists(temp_path):
+                    os.unlink(temp_path)
+        except Exception as e:
+            # Non-fatal - profile system works without example in user dir
+            logger.debug(f"Could not create example profile: {e}")
+
+    return PROFILES_DIR
+
+
+def apply_profile_to_args(
+    args,
+    profile: Profile,
+    tool: str,
+    explicit_args: Set[str]
+) -> None:
+    """Apply profile values to args, respecting explicit CLI overrides.
+
+    Args:
+        args: argparse Namespace to modify
+        profile: Profile to apply
+        tool: Must be 'specimux'
+        explicit_args: Set of argument names that were explicitly provided on CLI
+    """
+    if tool == 'specimux':
+        profile_values = profile.specimux
+    else:
+        raise ValueError(f"Unknown tool: {tool}")
+
+    for key, value in profile_values.items():
+        # Convert YAML key (with dashes) to argparse attribute name (with underscores)
+        attr_name = key.replace('-', '_')
+
+        # Only apply if not explicitly set on command line
+        if attr_name not in explicit_args:
+            if hasattr(args, attr_name):
+                logger.debug(f"Profile '{profile.name}': setting {attr_name}={value}")
+                setattr(args, attr_name, value)
+            else:
+                # This shouldn't happen if validation passed, but log it
+                logger.warning(
+                    f"Profile '{profile.name}': unknown attribute '{attr_name}'"
+                )
+
+
+def print_profiles_list(tool: str = 'specimux') -> None:
+    """Print available profiles to stdout.
+
+    Args:
+        tool: Tool name for usage hint (default: 'specimux')
+    """
+    if yaml is None:
+        print("Profile support requires PyYAML. Install with: pip install pyyaml")
+        return
+
+    # Initialize user profiles directory with example on first use
+    ensure_user_profiles_dir()
+
+    profiles = list_profiles()
+
+    if not profiles:
+        print(f"No profiles found.")
+        print(f"\nProfiles are stored in: {PROFILES_DIR}")
+        return
+
+    print(f"Available profiles:\n")
+
+    for name in profiles:
+        try:
+            # Load without version check to show all profiles
+            profile = Profile.load(name, check_version=False)
+
+            # Check if it's a user profile or bundled
+            user_path = PROFILES_DIR / f"{name}.yaml"
+            source = "user" if user_path.exists() else "bundled"
+
+            # Check version compatibility
+            compatible = check_version_compatible(profile.version, __version__)
+            compat_str = "" if compatible else " [INCOMPATIBLE]"
+
+            print(f"  {name} ({source}){compat_str}")
+            if profile.description:
+                print(f"    {profile.description}")
+            print(f"    Version: {profile.version}")
+            print()
+
+        except ProfileError as e:
+            print(f"  {name} [ERROR: {e}]")
+            print()
+
+    print(f"Usage: {tool} -p <profile> [other options]")
+    print(f"Profile directory: {PROFILES_DIR}")

--- a/src/specimux/profiles/default.yaml
+++ b/src/specimux/profiles/default.yaml
@@ -1,0 +1,12 @@
+# Default settings for dual-barcode demultiplexing
+#
+# These settings match specimux's built-in defaults and serve as
+# a starting point for creating custom profiles.
+
+specimux-version: "0.7.*"
+description: "Default dual-barcode demultiplexing"
+
+specimux:
+  trim: barcodes
+  dereplicate: best
+  search-len: 80

--- a/src/specimux/profiles/example.yaml
+++ b/src/specimux/profiles/example.yaml
@@ -1,0 +1,56 @@
+# Example Specimux Profile
+#
+# Copy this file to create your own profiles:
+#   cp example.yaml my-workflow.yaml
+#
+# Then use it with:
+#   specimux primers.fasta specimens.txt reads.fastq -p my-workflow
+#
+# HOW TO USE THIS FILE:
+#   - Lines starting with # are comments (ignored)
+#   - To enable an option, remove the # at the start of the line
+#   - Only include parameters you want to change from defaults
+#   - CLI arguments always override profile values
+#
+# Example: To set search-len to 120, change:
+#   # search-len: 80
+# to:
+#   search-len: 120
+
+specimux-version: "0.7.*"
+description: "My custom workflow"
+
+# =============================================================================
+# Parameters for specimux (demultiplexing)
+# =============================================================================
+specimux:
+
+  # --- Trimming ---
+  # trim: barcodes               # Trimming to apply: none, tails, barcodes, or primers
+
+  # --- Dereplication ---
+  # dereplicate: best            # Dereplication strategy: best or none
+
+  # --- Search Region ---
+  # search-len: 80               # Length to search for index and primer at each end
+
+  # --- Edit Distances ---
+  # index-edit-distance: -1      # Barcode edit distance (-1 = auto from barcode set)
+  # primer-edit-distance: -1     # Primer edit distance (-1 = auto from primer set)
+
+  # --- Length Filtering ---
+  # min-length: -1               # Minimum sequence length (-1 = no filtering)
+  # max-length: -1               # Maximum sequence length (-1 = no filtering)
+
+  # --- Processing ---
+  # threads: -1                  # Number of worker threads (-1 = auto-detect)
+
+  # --- Optimizations ---
+  # disable-prefilter: false     # Set true to disable bloom filter barcode prefiltering
+  # disable-preorient: false     # Set true to disable heuristic pre-orientation
+
+  # --- Subsampling ---
+  # sample-topq: 0              # Create subsample with top N reads by quality (0 = disabled)
+
+  # --- Diagnostics ---
+  # diagnostics: 1               # Diagnostic trace level: 1=standard, 2=detailed, 3=verbose

--- a/src/specimux/progress.py
+++ b/src/specimux/progress.py
@@ -1,0 +1,67 @@
+"""Optional JSONL progress reporting for orchestration tools."""
+
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+
+class ProgressReporter:
+    """Write JSONL progress lines to a file for external consumption.
+
+    When path is None, all methods are no-ops (zero overhead).
+    Progress lines are throttled to at most one per second.
+    """
+
+    def __init__(self, path: Optional[Path] = None):
+        self._path = path
+        self._file = None
+        self._last_write = 0.0
+        self._throttle = 1.0  # seconds between writes
+        if path:
+            self._file = open(path, 'w')
+
+    def update(self, processed: int, matched: int, total_est: int) -> None:
+        """Write a throttled progress line."""
+        if self._file is None:
+            return
+        now = time.monotonic()
+        if now - self._last_write < self._throttle:
+            return
+        self._last_write = now
+        rate = matched / processed if processed > 0 else 0.0
+        line = json.dumps({
+            "type": "progress",
+            "processed": processed,
+            "matched": matched,
+            "total_est": total_est,
+            "rate": round(rate, 4),
+        })
+        self._file.write(line + '\n')
+        self._file.flush()
+
+    def complete(self, processed: int, matched: int) -> None:
+        """Write the final completion line."""
+        if self._file is None:
+            return
+        rate = matched / processed if processed > 0 else 0.0
+        line = json.dumps({
+            "type": "complete",
+            "processed": processed,
+            "matched": matched,
+            "rate": round(rate, 4),
+        })
+        self._file.write(line + '\n')
+        self._file.flush()
+
+    def close(self) -> None:
+        """Close the progress file."""
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/src/specimux/watch.py
+++ b/src/specimux/watch.py
@@ -8,6 +8,7 @@ import sys
 import argparse
 import logging
 import os
+import warnings
 import time
 import json
 import subprocess
@@ -407,6 +408,15 @@ def build_specimux_args(args) -> list:
 
 def main():
     """Main entry point for specimux-watch command."""
+    warnings.warn(
+        "specimux-watch is deprecated and will be removed in a future release. "
+        "Use 'specimux-suite live' instead for live sequencing monitoring with "
+        "consensus and identification.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    logging.warning("specimux-watch is deprecated. Use 'specimux-suite live' instead.")
+
     args = parse_args(sys.argv)
 
     # Set up logging


### PR DESCRIPTION


Add profile system (-p/--profile, --list-profiles) for reusable parameter presets via YAML files in ~/.config/specimux/profiles/ or bundled with the package. Includes version compatibility checking and key validation.

Add JSONL progress reporting (--progress-file) for integration with orchestration tools like specimux-suite.

Deprecate specimux-watch in favor of specimux-suite live.

Fix explicit CLI argument detection for profile override logic.